### PR TITLE
treewide: minor cleanup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
 
     mkSystem = pkgs: system: hostname:
       pkgs.lib.nixosSystem {
-        system = system;
+        inherit system;
         modules = [
           ./modules/system/configuration.nix
           (./. + "/hosts/${hostname}/hardware-configuration.nix")

--- a/modules/system/configuration.nix
+++ b/modules/system/configuration.nix
@@ -10,7 +10,7 @@
   nixpkgs.config.allowUnfree = true;
 
   # Remove unecessary preinstalled packages
-  environment.defaultPackages = [];
+  environment.defaultPackages = lib.mkForce [];
 
   environment.sessionVariables = {GTK_USE_PORTAL = "1";};
 
@@ -180,7 +180,7 @@
   };
 
   # Sound (PipeWire)
-  sound.enable = true;
+  sound.enable = false;
   hardware.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {

--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -12,7 +12,6 @@ in {
     home.packages = with pkgs; [
       zsh
       fzf
-      zoxide
     ];
 
     programs.zoxide = {


### PR DESCRIPTION
Cleans up a few things such as the invalid override for defaultPackages, and the usage of `sound.enable` - which actually
has nothing to do with whether or not the system has sound, it only enables a few outdated ALSA related options internally.
