### PR TITLE
Fix PRIME Sync/Offload Configuration Issue

### DIFF
--- a/modules/nvidia-optimus/default.nix
+++ b/modules/nvidia-optimus/default.nix
@@ -19,7 +19,9 @@ in {
     ];
 
     hardware.nvidia.prime = {
-      offload.enable = true;
+      #  "PRIME Sync and Offload Mode cannot be enabled at the same time."
+      # https://nixos.wiki/wiki/Nvidia
+      offload.enable = false;
       nvidiaBusId = "PCI:1:0:0";
       intelBusId = "PCI:0:2:0";
       sync.enable = true;


### PR DESCRIPTION
As per the [NixOS Wiki Article on using Nvidia](https://nixos.wiki/wiki/Nvidia), `PRIME sync and Offload **cannot** be enabled at the same time`. 

I have assumed the user will want to have less screen tearing and disabled offloading. You could do it the other way (or even use `reverseSync = true; offload = false; sync=false;` if assuming a newer driver and GPU), whatever works with the project's decision making calculus on this particular subject is fine.

Just trying to help out *because* as of recent nixpkgs-unstable(s), trying to build using the present nvidia configurations would just throw one of those annoying Nix errors and not actually work, so this way you now know and I have done my civic Nix user duty trying to spare you from that perennial source of frustration Nix blesses us all with. 